### PR TITLE
Added Packer support. Updated TK syntax. Create tmate-slave service.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 .kitchen/
 .kitchen.local.yml
+vendor/cookbooks/
+packer_cache/*
+Gemfile.lock
+Berksfile.lock

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -1,7 +1,9 @@
 ---
-driver_plugin: vagrant
-driver_config:
-  require_chef_omnibus: true
+driver:
+  name: vagrant
+
+provisioner:
+  name: chef_solo
 
 platforms:
 - name: ubuntu-12.04
@@ -22,6 +24,7 @@ platforms:
     box_url: https://opscode-vm-bento.s3.amazonaws.com/vagrant/opscode_centos-5.9_provisionerless.box
 
 suites:
-- name: default
-  run_list: ["recipe[chef-tmate-slave]"]
-  attributes: {}
+  - name: default
+    run_list:
+      - recipe[tmate-slave::default]
+    attributes:

--- a/Berksfile
+++ b/Berksfile
@@ -1,0 +1,3 @@
+site :opscode
+
+metadata

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,11 @@
 source 'http://rubygems.org'
 
-gem 'test-kitchen'
 gem 'chef', '~> 11.8'
 gem 'rake'
 gem 'foodcritic'
 gem "berkshelf",  "~> 2.0"
+
+group :integration do
+  gem "test-kitchen", "~> 1.0"
+  gem "kitchen-vagrant"
+end

--- a/Gemfile
+++ b/Gemfile
@@ -4,3 +4,4 @@ gem 'test-kitchen'
 gem 'chef', '~> 11.8'
 gem 'rake'
 gem 'foodcritic'
+gem "berkshelf",  "~> 2.0"

--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ gem 'chef', '~> 11.8'
 gem 'rake'
 gem 'foodcritic'
 gem "berkshelf",  "~> 2.0"
+gem 'knife-solo'
 
 group :integration do
   gem "test-kitchen", "~> 1.0"

--- a/Rakefile
+++ b/Rakefile
@@ -30,6 +30,32 @@ task :prepare_sandbox do
  cp_r Dir.glob("{#{files.join(',')}}"), sandbox_path
 end
 
+desc "Cleanup Vendor directory"
+task :cleanup_vendor do
+  sh 'rm -rf vendor/cookbooks/*'
+end
+
+desc "Build AMI"
+task :packer_ami => [:cleanup_vendor, :packer_build_ami]
+
+task :packer_build_ami do
+  sh 'berks install --path vendor/cookbooks; packer build -only=amazon-ebs template.json'
+end
+
+desc "Build Droplet"
+task :packer_droplet => [:cleanup_vendor, :packer_build_droplet]
+
+task :packer_build_droplet do
+  sh 'berks install --path vendor/cookbooks; packer build -only=digitalocean template.json'
+end
+
+desc "Build Openstack"
+task :packer_openstack => [:cleanup_vendor, :packer_build_openstack]
+
+task :packer_build_openstack do
+  sh 'berks install --path vendor/cookbooks; packer build -only=openstack template.json'
+end
+
 private
 
 def prepare_foodcritic_sandbox(sandbox)

--- a/Rakefile
+++ b/Rakefile
@@ -56,6 +56,14 @@ task :packer_build_openstack do
   sh 'berks install --path vendor/cookbooks; packer build -only=openstack template.json'
 end
 
+desc 'Usage: rake knife_solo user={user} ip={ip.address.goes.here}'
+task :knife_solo do
+  sh 'rm -rf cookbooks && rm -rf nodes'
+  sh 'mkdir cookbooks && berks install --path cookbooks'
+  sh "mkdir nodes && echo '{\"run_list\":[\"tmate-slave::default\"]}' > nodes/#{ENV['ip']}.json"
+  sh "bundle exec knife solo bootstrap #{ENV['user']}@#{ENV['ip']}"
+end
+
 private
 
 def prepare_foodcritic_sandbox(sandbox)

--- a/files/default/init
+++ b/files/default/init
@@ -1,0 +1,18 @@
+description     "tmate slave"
+
+start on runlevel [2345]
+stop on runlevel [!2345]
+
+respawn
+
+script
+  OPTIONS=""
+  if [ -e /etc/default/tmate-slave ]
+  then
+    . /etc/default/tmate-slave
+    echo "Sourcing config file."
+  else
+    echo "Config file not available."
+  fi
+  exec /usr/bin/tmate-slave -k /root/keys/ -p 23 $OPTIONS
+end script

--- a/files/default/tmate-slave
+++ b/files/default/tmate-slave
@@ -1,0 +1,1 @@
+OPTIONS="-v"

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,4 +4,4 @@ maintainer_email 'jj.asghar@peopleadmin.com'
 license          'Apache 2.0'
 description      'Installs/Configures tmate-slave'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.1.0'
+version          '0.2.0'

--- a/recipes/tmate-slave_build.rb
+++ b/recipes/tmate-slave_build.rb
@@ -1,5 +1,5 @@
 
-git "/tmp/tmate-slave" do
+git "/root/tmate-slave" do
   repository "https://github.com/nviennot/tmate-slave.git"
   action :sync
   user "root"
@@ -9,15 +9,45 @@ end
 script "compile_tmate-slave_part1" do
     interpreter "bash"
       user "root"
-      cwd "/tmp/tmate-slave"
+      cwd "/root/tmate-slave"
       code <<-EOH
         STATUS=0
         bash create_keys.sh > /root/tmate-slave-footprints.txt || STATUS=1
-        cp -r /tmp/tmate-slave/keys /root/keys/
-        cd /tmp/tmate-slave
+        cp -r /root/tmate-slave/keys /root/keys/
+        cd /root/tmate-slave
         ./autogen.sh || STATUS=1
         ./configure || STATUS=1
         make || STATUS=1
+        cp tmate-slave /usr/bin/
+        chmod 755 /usr/bin/tmate-slave
         exit $STATUS
       EOH
+end
+
+case node["platform"]
+when "debian", "ubuntu"
+
+  cookbook_file '/etc/default/tmate-slave' do
+    source 'tmate-slave'
+    owner 'root'
+    group 'root'
+    mode '0644'
+  end
+
+  cookbook_file '/etc/init/tmate-slave.conf' do
+    source 'init'
+    owner 'root'
+    group 'root'
+    mode '0644'
+  end
+
+  link '/etc/init.d/tmate-slave' do
+    to '/lib/init/upstart-job'
+  end
+
+  service 'tmate-slave' do
+    supports :status => true
+    action [ :enable, :start ]
+  end
+
 end

--- a/template.json
+++ b/template.json
@@ -1,0 +1,50 @@
+{
+    "variables": {
+        "aws_access_key": "",
+        "aws_secret_key": ""
+    },
+
+    "builders": [{
+            "type": "amazon-ebs",
+            "access_key": "{{user `aws_access_key`}}",
+            "secret_key": "{{user `aws_secret_key` }}",
+            "region": "us-west-2",
+            "source_ami": "ami-8ab4dfba",
+            "instance_type": "c1.medium",
+            "ssh_username": "ubuntu",
+            "ami_name": "tmate-slave {{timestamp}}"
+            },
+            {
+              "type": "digitalocean",
+              "image_id": "3101045",
+              "size_id": "63",
+              "snapshot_name": "tmate-slave {{timestamp}}"
+            },
+            {
+              "type": "openstack",
+              "username": "",
+              "password": "",
+              "provider": "",
+              "region": "DFW",
+              "ssh_username": "root",
+              "image_name": "tmate-slave {{timestamp}}",
+              "source_image": "",
+              "flavor": "3"
+            },
+            {
+              "type": "googlecompute",
+              "project_id": "",
+              "bucket_name": "tmate-slave-packer-images",
+              "client_secrets_file": "google.json",
+              "private_key_file": "google.pem",
+              "source_image": "debian-7-wheezy-v20131120",
+              "zone": "us-central1-a",
+              "image_name": "tmate-slave-{{timestamp}}"
+            }],
+
+    "provisioners": [{
+      "type": "chef-solo",
+      "cookbook_paths": ["./vendor/cookbooks"],
+      "run_list": [ "tmate-slave" ]
+    }]
+}

--- a/test/integration/default/bats/tmate-slave.bats
+++ b/test/integration/default/bats/tmate-slave.bats
@@ -1,23 +1,36 @@
 #!/usr/bin/env bats
 
-@test "confirm keys are in /tmp/tmate-slave/keys/ssh_host_dsa_key.pub" {
-  run ls /tmp/tmate-slave/keys/ssh_host_dsa_key.pub
+@test "confirm keys are in /root/tmate-slave/keys/ssh_host_dsa_key.pub" {
+  run ls /root/tmate-slave/keys/ssh_host_dsa_key.pub
   [ "$status" -eq  0 ]
 }
 
-@test "confirm keys are in /tmp/tmate-slave/keys/ssh_host_dsa_key" {
-  run ls /tmp/tmate-slave/keys/ssh_host_dsa_key
+@test "confirm keys are in /root/tmate-slave/keys/ssh_host_dsa_key" {
+  run ls /root/tmate-slave/keys/ssh_host_dsa_key
   [ "$status" -eq  0 ]
-}
-
-@test "confirm that you changed tmate.io in tmate.h" {
-  run grep tmate.io /tmp/tmate-slave/tmate.h
-  [ "$status" -eq  1 ]
 }
 
 @test "confirm that tmate-slave is there" {
-  run ls /tmp/tmate-slave/tmate-slave
+  run ls /root/tmate-slave/tmate-slave
   [ "$status" -eq  0 ]
 }
 
+@test "confirm that the init/tmate-slave is there" {
+  run ls /etc/init/tmate-slave.conf
+  [ "$status" -eq  0 ]
+}
 
+@test "confirm that the default/tmate-slave is there" {
+  run ls /etc/default/tmate-slave
+  [ "$status" -eq  0 ]
+}
+
+@test "confirm that the init.d symlink is there" {
+  run ls /etc/init.d/tmate-slave
+  [ "$status" -eq  0 ]
+}
+
+@test "confirm that the binary installed" {
+  run ls /usr/bin/tmate-slave
+  [ "$status" -eq  0 ]
+}


### PR DESCRIPTION
When this builds, you have a tmate-slave service listening on port 23.

All BATS tests pass. (Removed one test that didn't work anymore.)

Added some Rakefile methods to build on AWS, Rackspace and DO.

Not sure if you're interested, but thought I'd over.
